### PR TITLE
Restructure of ShrinkRay & GrabbablePlayerList

### DIFF
--- a/LethalCompanyTemplate/Plugin.cs
+++ b/LethalCompanyTemplate/Plugin.cs
@@ -59,6 +59,7 @@ namespace LCShrinkRay
             {
                 // LC_API Network Setup
                 Network.RegisterAll(typeof(Shrinking));
+                Network.RegisterAll(typeof(ShrinkRay));
                 Network.RegisterAll(typeof(GrabbablePlayerObject));
                 Network.RegisterAll(typeof(GrabbablePlayerList));
             }

--- a/LethalCompanyTemplate/comp/GrabbablePlayerObject.cs
+++ b/LethalCompanyTemplate/comp/GrabbablePlayerObject.cs
@@ -152,6 +152,12 @@ namespace LCShrinkRay.comp
 
         private GrabbableObject grabbedPlayerCurrentItem()
         {
+            if (grabbedPlayer == null)
+            {
+                Plugin.log("GrabbedPlayer is null?!", Plugin.LogType.Error);
+                return null;
+            }
+
             if (grabbedPlayer.isHoldingObject && grabbedPlayer.ItemSlots[grabbedPlayer.currentItemSlot] != null)
                 return grabbedPlayer.ItemSlots[grabbedPlayer.currentItemSlot];
 

--- a/LethalCompanyTemplate/comp/ShrinkRay.cs
+++ b/LethalCompanyTemplate/comp/ShrinkRay.cs
@@ -368,6 +368,12 @@ namespace LCShrinkRay.comp
 
         public static void OnPlayerModification(PlayerControllerB targetPlayer, ModificationType type)
         {
+            if (targetPlayer == null || targetPlayer.gameObject == null || targetPlayer.gameObject.transform == null)
+            {
+                Plugin.log("Ay.. that's not a valid player somehow..");
+                return;
+            }
+
             var targetingUs = targetPlayer.playerClientId == PlayerHelper.currentPlayer().playerClientId;
             Plugin.log("Ray has hit " + (targetingUs ? "us" : "Player (" + targetPlayer.playerClientId + ")") + "!");
 
@@ -400,7 +406,7 @@ namespace LCShrinkRay.comp
                         if (newSize == targetPlayer.gameObject.transform.localScale.x)
                             return; // Well, nothing changed..
 
-                        if (newSize <= 0 && targetPlayer.AllowPlayerDeath())
+                        if (newSize <= 0 && !targetPlayer.AllowPlayerDeath())
                             return; // Can't shrink players to death in ship phase
 
                         Plugin.log("Raytype: " + type.ToString() + ". New size: " + newSize);

--- a/LethalCompanyTemplate/comp/ShrinkRay.cs
+++ b/LethalCompanyTemplate/comp/ShrinkRay.cs
@@ -414,7 +414,7 @@ namespace LCShrinkRay.comp
                             coroutines.ObjectShrinkAnimation.StartRoutine(targetPlayer.gameObject, newSize);
 
                         if (NetworkManager.Singleton.IsServer) // todo: create a mechanism that only allows larger players to grab small ones
-                            GrabbablePlayerList.setPlayerGrabbable(targetPlayer.gameObject);
+                            GrabbablePlayerList.SetPlayerGrabbable(targetPlayer);
 
                         if (targetingUs)
                             Vents.SussifyAll();

--- a/LethalCompanyTemplate/comp/ShrinkRay.cs
+++ b/LethalCompanyTemplate/comp/ShrinkRay.cs
@@ -414,7 +414,7 @@ namespace LCShrinkRay.comp
                             coroutines.ObjectShrinkAnimation.StartRoutine(targetPlayer.gameObject, newSize);
 
                         if (PlayerHelper.isHost()) // todo: create a mechanism that only allows larger players to grab small ones
-                            GrabbablePlayerList.SetPlayerGrabbable(targetPlayer);
+                            GrabbablePlayerList.SetPlayerGrabbableServer(targetPlayer);
 
                         if (targetingUs)
                             Vents.SussifyAll();

--- a/LethalCompanyTemplate/comp/ShrinkRay.cs
+++ b/LethalCompanyTemplate/comp/ShrinkRay.cs
@@ -142,6 +142,9 @@ namespace LCShrinkRay.comp
         {
             base.Update();
 
+            if (isPocketed)
+                return;
+
             //if beam exists
             try
             { // todo: move to coroutine
@@ -300,7 +303,7 @@ namespace LCShrinkRay.comp
             if (hit.transform.TryGetComponent<PlayerControllerB>(out PlayerControllerB component))
             {
                 Plugin.log($"Ray has hit player " + component.playerClientId);
-                if (component.transform.localScale.x == 1f && component.playerClientId != this.playerHeldBy.playerClientId)
+                if (component.playerClientId != this.playerHeldBy.playerClientId)
                 {
                     OnPlayerModification(component, type);
                     Network.Broadcast("OnPlayerModificationSync", new PlayerModificationData() { playerID = component.playerClientId, modificationType = type });
@@ -339,6 +342,7 @@ namespace LCShrinkRay.comp
         [NetworkMessage("OnPlayerModificationSync")]
         public static void OnPlayerModificationSync(ulong sender, PlayerModificationData modificationData)
         {
+            Plugin.log("Player (" + sender + ") modified Player(" + modificationData.playerID + "): " + modificationData.modificationType.ToString());
             var targetPlayer = PlayerHelper.GetPlayerController(modificationData.playerID);
             if (targetPlayer == null)
                 return;
@@ -414,11 +418,6 @@ namespace LCShrinkRay.comp
             }
         }
 
-        //Player Shrink animation, shrinks a player over a sinusoidal curve for a duration. Requires the player and mask transforms.
-        public static void changeCurrentPlayerSize(float shrinkAmt, GameObject playerObj, Transform maskTransform)
-        {
-        }
-
         // ------ Ray hitting Object ------
         public static void OnObjectModification(GameObject targetObject)
         {
@@ -427,12 +426,14 @@ namespace LCShrinkRay.comp
 
         public override void EquipItem()
         {
+            // idea: play a fading-in sound, like energy of gun is loading
             base.EquipItem();
             previousPlayerHeldBy = playerHeldBy;
             previousPlayerHeldBy.equippedUsableItemQE = true;
         }
         public override void PocketItem()
         {
+            // idea: play a fading-out sound
             base.PocketItem();
         }
 

--- a/LethalCompanyTemplate/comp/Vents.cs
+++ b/LethalCompanyTemplate/comp/Vents.cs
@@ -122,6 +122,7 @@ namespace LCShrinkRay.comp
         // when unshrinking will be a thing
         public static void unsussifyAll()
         {
+            return;
             foreach (var vent in getAllVents())
                 unsussify(vent);
 

--- a/LethalCompanyTemplate/comp/Vents.cs
+++ b/LethalCompanyTemplate/comp/Vents.cs
@@ -122,6 +122,7 @@ namespace LCShrinkRay.comp
         // when unshrinking will be a thing
         public static void unsussifyAll()
         {
+            return; // wip
             foreach (var vent in getAllVents())
                 unsussify(vent);
 

--- a/LethalCompanyTemplate/comp/Vents.cs
+++ b/LethalCompanyTemplate/comp/Vents.cs
@@ -122,7 +122,6 @@ namespace LCShrinkRay.comp
         // when unshrinking will be a thing
         public static void unsussifyAll()
         {
-            return;
             foreach (var vent in getAllVents())
                 unsussify(vent);
 

--- a/LethalCompanyTemplate/comp/Vents.cs
+++ b/LethalCompanyTemplate/comp/Vents.cs
@@ -17,8 +17,19 @@ namespace LCShrinkRay.comp
     {
         private static bool sussification = false;
 
+        private static EnemyVent[] getAllVents()
+        {
+            if (RoundManager.Instance.allEnemyVents != null && RoundManager.Instance.allEnemyVents.Length > 0)
+                return RoundManager.Instance.allEnemyVents;
+
+            return UnityEngine.Object.FindObjectsOfType<EnemyVent>();
+        }
+
         public static void SussifyAll()
         {
+            if (!GameNetworkManager.Instance.gameHasStarted)
+                return;
+
             if(sussification) // Already sussified
                 return;
 
@@ -36,15 +47,11 @@ namespace LCShrinkRay.comp
 
             Plugin.log("SUSSIFYING VENTS");
 
-            var vents = RoundManager.Instance.allEnemyVents;
+            var vents = getAllVents();
             if (vents == null || vents.Length == 0)
             {
-                vents = UnityEngine.Object.FindObjectsOfType<EnemyVent>();
-                if (vents == null || vents.Length == 0)
-                {
-                    Plugin.log("No vents to sussify.");
-                    return;
-                }
+                Plugin.log("No vents to sussify.");
+                return;
             }
 
             GameObject dungeonEntrance = GameObject.Find("EntranceTeleportA(Clone)");
@@ -71,6 +78,12 @@ namespace LCShrinkRay.comp
         public static void sussify(EnemyVent enemyVent, EnemyVent siblingVent)
         {
             GameObject vent = enemyVent.gameObject.transform.Find("Hinge").gameObject.transform.Find("VentCover").gameObject;
+            if (!vent)
+            {
+                Plugin.log("Vent has no cover to sussify");
+                return;
+            }
+
             vent.GetComponent<MeshRenderer>();
             vent.tag = "InteractTrigger";
             vent.layer = LayerMask.NameToLayer("InteractableObject");
@@ -107,15 +120,37 @@ namespace LCShrinkRay.comp
         }
 
         // when unshrinking will be a thing
-        /*public static void unsussifyAll()
+        public static void unsussifyAll()
         {
-            
+            foreach (var vent in getAllVents())
+                unsussify(vent);
+
+            sussification = false;
         }
 
         public static void unsussify(EnemyVent enemyVent)
         {
+            GameObject vent = enemyVent.gameObject.transform.Find("Hinge").gameObject.transform.Find("VentCover").gameObject;
+            if (!vent)
+                return;
+
+            Plugin.log("0");
+            if (enemyVent.gameObject.AddComponent<SussifiedVent>() != null)
+            {
+                Plugin.log("1");
+                UnityEngine.Object.Destroy(enemyVent.gameObject.AddComponent<SussifiedVent>());
+            }
+            if (vent.GetComponent<BoxCollider>() != null)
+            {
+                Plugin.log("2");
+                UnityEngine.Object.Destroy(vent.GetComponent<BoxCollider>());
+            }
+            if (vent.GetComponent<InteractTrigger>() != null)
+            {
+                Plugin.log("3");
+                UnityEngine.Object.Destroy(vent.GetComponent<InteractTrigger>());
+            }
         }
-        */
 
 
         internal class SussifiedVent : NetworkBehaviour

--- a/LethalCompanyTemplate/config/ModConfig.cs
+++ b/LethalCompanyTemplate/config/ModConfig.cs
@@ -9,6 +9,7 @@ using Unity.Collections;
 using Unity.Netcode;
 using GameNetcodeStuff;
 using static UnityEngine.InputSystem.InputRemoting;
+using LCShrinkRay.helper;
 
 namespace LCShrinkRay.Config
 {
@@ -116,7 +117,7 @@ namespace LCShrinkRay.Config
             [HarmonyPostfix]
             public static void Initialize()
             {
-                if (NetworkManager.Singleton.IsServer)
+                if (PlayerHelper.isHost())
                 {
                     Plugin.log("Current player is the host.");
                     NetworkManager.Singleton.CustomMessagingManager.RegisterNamedMessageHandler(PluginInfo.PLUGIN_NAME + "_HostConfigRequested", new HandleNamedMessageDelegate(HostConfigRequested));
@@ -142,7 +143,7 @@ namespace LCShrinkRay.Config
 
             public static void HostConfigRequested(ulong clientId, FastBufferReader reader)
             {
-                if (!NetworkManager.Singleton.IsServer) // Current player is not the host and therefor not the one who should react
+                if (!PlayerHelper.isHost()) // Current player is not the host and therefor not the one who should react
                     return;
 
                 string json = JsonConvert.SerializeObject(ModConfig.Instance.values);

--- a/LethalCompanyTemplate/config/ModConfig.cs
+++ b/LethalCompanyTemplate/config/ModConfig.cs
@@ -82,8 +82,7 @@ namespace LCShrinkRay.Config
         public void setup()
         {
             values.shrinkRayCost            = Plugin.bepInExConfig().Bind("General", "ShrinkRayCost", 0, "Store cost of the shrink ray").Value;
-            //sizeDecrease                  = Plugin.bepInExConfig().Bind("General", "SizeDecrease", SizeDecrease.Half, "Defines how tiny shrunken players will become.\"").Value;
-            //values.multipleShrinking      = Plugin.bepInExConfig().Bind("General", "MultipleShrinking", true, "If true, a player can shrink multiple times.. unfortunatly.").Value;
+            values.multipleShrinking        = Plugin.bepInExConfig().Bind("General", "MultipleShrinking", true, "If true, a player can shrink multiple times.. unfortunatly.").Value;
 
             values.movementSpeedMultiplier  = Plugin.bepInExConfig().Bind("Shrunken", "MovementSpeedMultiplier", 1.5f, new ConfigDescription("Speed multiplier for shrunken players, ranging from 0.5 (slow) to 2 (fast).", new AcceptableValueRange<float>(0.5f, 2f))).Value;
             values.jumpHeightMultiplier     = Plugin.bepInExConfig().Bind("Shrunken", "JumpHeightMultiplier", 1.5f, new ConfigDescription("Jump-height multiplier for shrunken players, ranging from 0.5 (lower) to 2 (higher).", new AcceptableValueRange<float>(0.5f, 2f))).Value;

--- a/LethalCompanyTemplate/coroutines/ObjectShrinkAnimation.cs
+++ b/LethalCompanyTemplate/coroutines/ObjectShrinkAnimation.cs
@@ -9,14 +9,14 @@ namespace LCShrinkRay.coroutines
     {
         public GameObject playerObj { get; private set; }
 
-        public static void StartRoutine(GameObject playerObj, float newSize)
+        public static void StartRoutine(GameObject playerObj, float newSize, Action onComplete = null)
         {
             var routine = playerObj.AddComponent<ObjectShrinkAnimation>();
             routine.playerObj = playerObj;
-            routine.StartCoroutine(routine.run(newSize));
+            routine.StartCoroutine(routine.run(newSize, onComplete));
         }
 
-        private IEnumerator run(float newSize)
+        private IEnumerator run(float newSize, Action onComplete)
         {
             Plugin.log("ENTERING COROUTINE OBJECT SHRINK", Plugin.LogType.Warning);
             Plugin.log("gObject: " + playerObj, Plugin.LogType.Warning);
@@ -52,6 +52,9 @@ namespace LCShrinkRay.coroutines
             // Ensure final scale is set to the desired value
             objectTransform.localScale = new Vector3(newSize, newSize, newSize);
             Shrinking.Instance.updatePitch();
+
+            if (onComplete != null)
+                onComplete();
         }
     }
 }

--- a/LethalCompanyTemplate/coroutines/ObjectShrinkAnimation.cs
+++ b/LethalCompanyTemplate/coroutines/ObjectShrinkAnimation.cs
@@ -5,39 +5,43 @@ using UnityEngine;
 
 namespace LCShrinkRay.coroutines
 {
-    internal class ObjectShrinkAnimation : MonoBehaviour
+    internal class ObjectShrinkAnimation : MonoBehaviour // todo: rename to ObjectChangeSizeAnimation
     {
         public GameObject playerObj { get; private set; }
 
-        public static void StartRoutine(GameObject playerObj, float shrinkAmt)
+        public static void StartRoutine(GameObject playerObj, float newSize)
         {
             var routine = playerObj.AddComponent<ObjectShrinkAnimation>();
             routine.playerObj = playerObj;
-            routine.StartCoroutine(routine.run(shrinkAmt));
+            routine.StartCoroutine(routine.run(newSize));
         }
 
-        private IEnumerator run(float shrinkAmt)
+        private IEnumerator run(float newSize)
         {
             Plugin.log("ENTERING COROUTINE OBJECT SHRINK", Plugin.LogType.Warning);
             Plugin.log("gObject: " + playerObj, Plugin.LogType.Warning);
             Transform objectTransform = playerObj.GetComponent<Transform>();
             float duration = 2f;
             float elapsedTime = 0f;
-            float shrinkage = 1f;
+            float currentSize = playerObj.transform.localScale.x;
+            if (currentSize == newSize)
+                yield break;
 
-            while (elapsedTime < duration && shrinkage > shrinkAmt)
+            var modificationType = newSize < currentSize ? ShrinkRay.ModificationType.Shrinking : ShrinkRay.ModificationType.Enlarging;
+
+            while (elapsedTime < duration && modificationType == ShrinkRay.ModificationType.Shrinking ? (currentSize > newSize) : (currentSize < newSize))
             {
                 //shrinkage = -(Mathf.Pow(elapsedTime / duration, 3) - (elapsedTime / duration) * amplitude * Mathf.Sin((elapsedTime / duration) * Mathf.PI)) + 1f;
-                shrinkage = (float)(0.58 * Math.Sin((4 * elapsedTime / duration) + 0.81) + 0.58);
+                currentSize = (float)(0.58 * Math.Sin((4 * elapsedTime / duration) + 0.81) + 0.58);
                 //mls.LogFatal(shrinkage);
-                objectTransform.localScale = new Vector3(shrinkage, shrinkage, shrinkage);
+                objectTransform.localScale = new Vector3(currentSize, currentSize, currentSize);
 
                 elapsedTime += Time.deltaTime;
                 yield return null; // Wait for the next frame
             }
 
             // Ensure final scale is set to the desired value
-            objectTransform.localScale = new Vector3(shrinkAmt, shrinkAmt, shrinkAmt);
+            objectTransform.localScale = new Vector3(newSize, newSize, newSize);
             Shrinking.Instance.updatePitch();
         }
     }

--- a/LethalCompanyTemplate/coroutines/ObjectShrinkAnimation.cs
+++ b/LethalCompanyTemplate/coroutines/ObjectShrinkAnimation.cs
@@ -28,12 +28,21 @@ namespace LCShrinkRay.coroutines
                 yield break;
 
             var modificationType = newSize < currentSize ? ShrinkRay.ModificationType.Shrinking : ShrinkRay.ModificationType.Enlarging;
+            float directionalForce, offset;
+            if (modificationType == ShrinkRay.ModificationType.Shrinking)
+            {
+                directionalForce = 0.58f;
+                offset = currentSize - 0.42f;
+            }
+            else
+            {
+                directionalForce = -0.58f;
+                offset = currentSize + 0.42f;
+            }
 
             while (elapsedTime < duration && modificationType == ShrinkRay.ModificationType.Shrinking ? (currentSize > newSize) : (currentSize < newSize))
             {
-                //shrinkage = -(Mathf.Pow(elapsedTime / duration, 3) - (elapsedTime / duration) * amplitude * Mathf.Sin((elapsedTime / duration) * Mathf.PI)) + 1f;
-                currentSize = (float)(0.58 * Math.Sin((4 * elapsedTime / duration) + 0.81) + 0.58);
-                //mls.LogFatal(shrinkage);
+                currentSize = (float)(directionalForce * Math.Sin((4 * elapsedTime / duration) + 0.81) + offset);
                 objectTransform.localScale = new Vector3(currentSize, currentSize, currentSize);
 
                 elapsedTime += Time.deltaTime;

--- a/LethalCompanyTemplate/coroutines/PlayerShrinkAnimation.cs
+++ b/LethalCompanyTemplate/coroutines/PlayerShrinkAnimation.cs
@@ -11,14 +11,14 @@ namespace LCShrinkRay.coroutines
     {
         public GameObject playerObj { get; private set; }
 
-        public static void StartRoutine(GameObject playerObj, float newSize, Transform maskTransform)
+        public static void StartRoutine(GameObject playerObj, float newSize, Transform maskTransform, Action onComplete = null)
         {
             var routine = playerObj.AddComponent<PlayerShrinkAnimation>();
             routine.playerObj = playerObj;
-            routine.StartCoroutine(routine.run(newSize, maskTransform));
+            routine.StartCoroutine(routine.run(newSize, maskTransform, onComplete));
         }
 
-        private IEnumerator run(float newSize, Transform maskTransform)
+        private IEnumerator run(float newSize, Transform maskTransform, Action onComplete)
         {
             Shrinking.Instance.playerTransform = playerObj.GetComponent<Transform>();
             //TODO: REPLACE WITH STORED REFERENCE
@@ -62,6 +62,9 @@ namespace LCShrinkRay.coroutines
             maskTransform.localPosition = CalcMaskPosVec(newSize);
             armTransform.localScale = CalcArmScale(newSize);
             Shrinking.Instance.updatePitch();
+
+            if(onComplete != null)
+                onComplete();
         }
         private Vector3 CalcMaskPosVec(float scale)
         {

--- a/LethalCompanyTemplate/coroutines/PlayerShrinkAnimation.cs
+++ b/LethalCompanyTemplate/coroutines/PlayerShrinkAnimation.cs
@@ -11,14 +11,14 @@ namespace LCShrinkRay.coroutines
     {
         public GameObject playerObj { get; private set; }
 
-        public static void StartRoutine(GameObject playerObj, float shrinkAmt, Transform maskTransform)
+        public static void StartRoutine(GameObject playerObj, float newSize, Transform maskTransform)
         {
             var routine = playerObj.AddComponent<PlayerShrinkAnimation>();
             routine.playerObj = playerObj;
-            routine.StartCoroutine(routine.run(shrinkAmt, maskTransform));
+            routine.StartCoroutine(routine.run(newSize, maskTransform));
         }
 
-        private IEnumerator run(float shrinkAmt, Transform maskTransform)
+        private IEnumerator run(float newSize, Transform maskTransform)
         {
             Shrinking.Instance.playerTransform = playerObj.GetComponent<Transform>();
             //TODO: REPLACE WITH STORED REFERENCE
@@ -27,55 +27,57 @@ namespace LCShrinkRay.coroutines
             Transform armTransform = Shrinking.Instance.playerTransform.Find("ScavengerModel").Find("metarig").Find("ScavengerModelArmsOnly");
             float duration = 2f;
             float elapsedTime = 0f;
-            float shrinkage = 1f;
+            float currentSize = playerObj.transform.localScale.x;
 
-            while (elapsedTime < duration && shrinkage > shrinkAmt)
+            var modificationType = newSize < currentSize ? ShrinkRay.ModificationType.Shrinking : ShrinkRay.ModificationType.Enlarging;
+
+            while (elapsedTime < duration && modificationType == ShrinkRay.ModificationType.Shrinking ? (currentSize > newSize) : (currentSize < newSize))
             {
                 //shrinkage = -(Mathf.Pow(elapsedTime / duration, 3) - (elapsedTime / duration) * amplitude * Mathf.Sin((elapsedTime / duration) * Mathf.PI)) + 1f;
-                shrinkage = (float)(0.58 * Math.Sin((4 * elapsedTime / duration) + 0.81) + 0.58);
+                currentSize = (float)(0.58 * Math.Sin((4 * elapsedTime / duration) + 0.81) + 0.58);
                 //mls.LogFatal(shrinkage);
-                Shrinking.Instance.playerTransform.localScale = new Vector3(shrinkage, shrinkage, shrinkage);
-                maskTransform.localScale = CalcMaskScaleVec(shrinkage);
-                maskTransform.localPosition = CalcMaskPosVec(shrinkage);
-                armTransform.localScale = CalcArmScale(shrinkage);
+                Shrinking.Instance.playerTransform.localScale = new Vector3(currentSize, currentSize, currentSize);
+                maskTransform.localScale = CalcMaskScaleVec(currentSize);
+                maskTransform.localPosition = CalcMaskPosVec(currentSize);
+                armTransform.localScale = CalcArmScale(currentSize);
 
                 elapsedTime += Time.deltaTime;
                 yield return null; // Wait for the next frame
             }
 
             // Ensure final scale is set to the desired value
-            Shrinking.Instance.playerTransform.localScale = new Vector3(shrinkAmt, shrinkAmt, shrinkAmt);
-            maskTransform.localScale = CalcMaskScaleVec(shrinkAmt);
-            maskTransform.localPosition = CalcMaskPosVec(shrinkAmt);
-            armTransform.localScale = CalcArmScale(shrinkAmt);
+            Shrinking.Instance.playerTransform.localScale = new Vector3(newSize, newSize, newSize);
+            maskTransform.localScale = CalcMaskScaleVec(newSize);
+            maskTransform.localPosition = CalcMaskPosVec(newSize);
+            armTransform.localScale = CalcArmScale(newSize);
             Shrinking.Instance.updatePitch();
         }
-        private Vector3 CalcMaskPosVec(float shrinkScale)
+        private Vector3 CalcMaskPosVec(float scale)
         {
             Vector3 pos;
             float x = 0;
-            float y = 0.00375f * shrinkScale + 0.05425f;
-            float z = 0.005f * shrinkScale - 0.279f;
+            float y = 0.00375f * scale + 0.05425f;
+            float z = 0.005f * scale - 0.279f;
             pos = new Vector3(x, y, z);
             return pos;
         }
 
-        private Vector3 CalcMaskScaleVec(float shrinkScale)
+        private Vector3 CalcMaskScaleVec(float scale)
         {
             Vector3 pos;
-            float x = 0.277f * shrinkScale + 0.2546f;
-            float y = 0.2645f * shrinkScale + 0.267f;
-            float z = 0.177f * shrinkScale + 0.3546f;
+            float x = 0.277f * scale + 0.2546f;
+            float y = 0.2645f * scale + 0.267f;
+            float z = 0.177f * scale + 0.3546f;
             pos = new Vector3(x, y, z);
             return pos;
         }
 
-        private Vector3 CalcArmScale(float shrinkScale)
+        private Vector3 CalcArmScale(float scale)
         {
             Vector3 pos;
-            float x = 0.35f * shrinkScale + 0.58f;
-            float y = -0.0625f * shrinkScale + 1.0625f;
-            float z = -0.125f * shrinkScale + 1.15f;
+            float x = 0.35f * scale  + 0.58f;
+            float y = -0.0625f * scale + 1.0625f;
+            float z = -0.125f * scale + 1.15f;
             pos = new Vector3(x, y, z);
             return pos;
         }

--- a/LethalCompanyTemplate/coroutines/PlayerShrinkAnimation.cs
+++ b/LethalCompanyTemplate/coroutines/PlayerShrinkAnimation.cs
@@ -30,11 +30,22 @@ namespace LCShrinkRay.coroutines
             float currentSize = playerObj.transform.localScale.x;
 
             var modificationType = newSize < currentSize ? ShrinkRay.ModificationType.Shrinking : ShrinkRay.ModificationType.Enlarging;
+            float directionalForce, offset;
+            if (modificationType == ShrinkRay.ModificationType.Shrinking)
+            {
+                directionalForce = 0.58f;
+                offset = currentSize - 0.42f;
+            }
+            else
+            {
+                directionalForce = -0.58f;
+                offset = currentSize + 0.42f;
+            }
 
             while (elapsedTime < duration && modificationType == ShrinkRay.ModificationType.Shrinking ? (currentSize > newSize) : (currentSize < newSize))
             {
                 //shrinkage = -(Mathf.Pow(elapsedTime / duration, 3) - (elapsedTime / duration) * amplitude * Mathf.Sin((elapsedTime / duration) * Mathf.PI)) + 1f;
-                currentSize = (float)(0.58 * Math.Sin((4 * elapsedTime / duration) + 0.81) + 0.58);
+                currentSize = (float)(directionalForce * Math.Sin((4 * elapsedTime / duration) + 0.81) + offset);
                 //mls.LogFatal(shrinkage);
                 Shrinking.Instance.playerTransform.localScale = new Vector3(currentSize, currentSize, currentSize);
                 maskTransform.localScale = CalcMaskScaleVec(currentSize);

--- a/LethalCompanyTemplate/helper/PlayerMethods.cs
+++ b/LethalCompanyTemplate/helper/PlayerMethods.cs
@@ -83,13 +83,14 @@ namespace LCShrinkRay.helper
 
         public static float currentPlayerScale()
         {
-            if (!currentPlayer() || !currentPlayer().gameObject)
+            var player = currentPlayer();
+            if (!player || !player.gameObject)
             {
                 Plugin.log("unable to retrieve currentPlayerScale!");
                 return 1f;
             }
 
-            return currentPlayer().gameObject.transform.localScale.x;
+            return player.gameObject.transform.localScale.x;
         }
 
         public static bool isShrunk(GameObject playerObject)
@@ -100,6 +101,6 @@ namespace LCShrinkRay.helper
             return isShrunk(playerObject.transform.localScale.x);
         }
         public static bool isCurrentPlayerShrunk() { return isShrunk(currentPlayerScale()); }
-        public static bool isShrunk(float size) { return size < 1f; }
+        public static bool isShrunk(float size) { return size < 0.9f; } // used 1f here, which lead to weird behaviour. added 0.1f tolerance
     }
 }

--- a/LethalCompanyTemplate/helper/PlayerMethods.cs
+++ b/LethalCompanyTemplate/helper/PlayerMethods.cs
@@ -46,6 +46,16 @@ namespace LCShrinkRay.helper
             return StartOfRound.Instance.allPlayerScripts.Where(pcb => pcb.isPlayerControlled).Select(pcb => pcb.gameObject).ToList();
         }
 
+        public static PlayerControllerB GetPlayerController(ulong playerID)
+        {
+            foreach(var pcb in StartOfRound.Instance.allPlayerScripts)
+            {
+                if (pcb.playerClientId == playerID)
+                    return pcb;
+            }
+            return null;
+        }
+
         public static GameObject GetPlayerObject(ulong playerID)
         {
             string myPlayerObjectName = "Player";
@@ -53,6 +63,17 @@ namespace LCShrinkRay.helper
                 myPlayerObjectName = "Player (" + playerID.ToString() + ")";
 
             return GameObject.Find(myPlayerObjectName);
+        }
+
+        public static ulong? GetPlayerID(GameObject gameObject)
+        {
+            if (gameObject.name.Contains('('))
+            {
+                int startIndex = gameObject.name.IndexOf("(");
+                int endIndex = gameObject.name.IndexOf(")");
+                return ulong.Parse(gameObject.name.Substring(startIndex + 1, endIndex - startIndex - 1));
+            }
+            return null;
         }
 
         public static PlayerControllerB currentPlayer()

--- a/LethalCompanyTemplate/patches/DebugPatches.cs
+++ b/LethalCompanyTemplate/patches/DebugPatches.cs
@@ -47,15 +47,15 @@ namespace LCShrinkRay.patches
                 else if (Keyboard.current.f2Key.wasPressedThisFrame)
                 {
                     Plugin.log("Shrinking player model");
-                    OnRayHitPlayer(PlayerHelper.currentPlayer());
-                    Network.Broadcast("OnRayHitPlayerSync", new PlayerHitData() { playerID = PlayerHelper.currentPlayer().playerClientId, modificationType = ModificationType.Shrinking });
+                    OnPlayerModification(PlayerHelper.currentPlayer(), ModificationType.Shrinking);
+                    Network.Broadcast("OnPlayerModificationSync", new PlayerModificationData() { playerID = PlayerHelper.currentPlayer().playerClientId, modificationType = ModificationType.Shrinking });
                 }
 
                 else if (Keyboard.current.f3Key.wasPressedThisFrame)
                 {
                     Plugin.log("Growing player model");
-                    OnRayHitPlayer(PlayerHelper.currentPlayer());
-                    Network.Broadcast("OnRayHitPlayerSync", new PlayerHitData() { playerID = PlayerHelper.currentPlayer().playerClientId, modificationType = ModificationType.Growing });
+                    OnPlayerModification(PlayerHelper.currentPlayer(), ModificationType.Enlarging);
+                    Network.Broadcast("OnPlayerModificationSync", new PlayerModificationData() { playerID = PlayerHelper.currentPlayer().playerClientId, modificationType = ModificationType.Enlarging });
                 }
 
                 else if (Keyboard.current.f4Key.wasPressedThisFrame)
@@ -63,8 +63,8 @@ namespace LCShrinkRay.patches
                     foreach(var pcb in StartOfRound.Instance.allPlayerScripts)
                     {
                         Plugin.log("Shrinking Player (" + pcb.playerClientId + ")");
-                        OnRayHitPlayer(pcb);
-                        Network.Broadcast("OnRayHitPlayerSync", new PlayerHitData() { playerID = pcb.playerClientId, modificationType = ModificationType.Shrinking });
+                        OnPlayerModification(pcb, ModificationType.Shrinking);
+                        Network.Broadcast("OnPlayerModificationSync", new PlayerModificationData() { playerID = pcb.playerClientId, modificationType = ModificationType.Shrinking });
                     }
                 }
 
@@ -73,8 +73,8 @@ namespace LCShrinkRay.patches
                     foreach (var pcb in StartOfRound.Instance.allPlayerScripts)
                     {
                         Plugin.log("Growing Player (" + pcb.playerClientId + ")");
-                        OnRayHitPlayer(pcb);
-                        Network.Broadcast("OnRayHitPlayerSync", new PlayerHitData() { playerID = pcb.playerClientId, modificationType = ModificationType.Growing });
+                        OnPlayerModification(pcb, ModificationType.Enlarging);
+                        Network.Broadcast("OnPlayerModificationSync", new PlayerModificationData() { playerID = pcb.playerClientId, modificationType = ModificationType.Enlarging });
                     }
                 }
 

--- a/LethalCompanyTemplate/patches/GameNetworkManagerPatch.cs
+++ b/LethalCompanyTemplate/patches/GameNetworkManagerPatch.cs
@@ -40,8 +40,8 @@ namespace LCShrinkRay.patches
                 {
                     if(PlayerHelper.isShrunk(player.gameObject))
                     {
-                        OnRayHitPlayer(PlayerHelper.currentPlayer());
-                        Network.Broadcast("OnRayHitPlayerSync", new PlayerHitData() { playerID = PlayerHelper.currentPlayer().playerClientId, modificationType = ModificationType.Normalizing });
+                        OnPlayerModification(PlayerHelper.currentPlayer(), ModificationType.Normalizing);
+                        Network.Broadcast("OnPlayerModificationSync", new PlayerModificationData() { playerID = PlayerHelper.currentPlayer().playerClientId, modificationType = ModificationType.Normalizing });
                     }
                 }
 

--- a/LethalCompanyTemplate/patches/GameNetworkManagerPatch.cs
+++ b/LethalCompanyTemplate/patches/GameNetworkManagerPatch.cs
@@ -1,11 +1,13 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
+using LC_API.Networking;
 using LCShrinkRay.comp;
 using LCShrinkRay.helper;
 using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using static LCShrinkRay.comp.ShrinkRay;
 
 namespace LCShrinkRay.patches
 {
@@ -34,12 +36,18 @@ namespace LCShrinkRay.patches
             if (true)
             {
                 Plugin.log("EndOfGame host");
-                //reset players size, speed, pitch(if it doesn't reset naturally)
-                foreach (PlayerControllerB player in StartOfRound.Instance.allPlayerScripts)
+                foreach (PlayerControllerB player in StartOfRound.Instance.allPlayerScripts) // reset player sizes
                 {
-                    Shrinking.ShrinkPlayer(player.gameObject, 1, player.playerClientId);
-                    PlayerControllerBPatch.defaultsInitialized = false;
+                    if(PlayerHelper.isShrunk(player.gameObject))
+                    {
+                        OnRayHitPlayer(PlayerHelper.currentPlayer());
+                        Network.Broadcast("OnRayHitPlayerSync", new PlayerHitData() { playerID = PlayerHelper.currentPlayer().playerClientId, modificationType = ModificationType.Normalizing });
+                    }
                 }
+
+                //reset speed, pitch(if it doesn't reset naturally)
+                PlayerControllerBPatch.defaultsInitialized = false;
+                Vents.unsussifyAll();
             }
         }
     }

--- a/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
+++ b/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
@@ -15,7 +15,7 @@ namespace LCShrinkRay.patches
         // After client joined
         [HarmonyPatch(typeof(StartOfRound), "OnClientConnect")]
         [HarmonyPostfix]
-        public static void OnClientConnect(StartOfRound __instance, ulong clientId)
+        public static void OnClientConnect(ulong clientId)
         {
             // cigarette
             Plugin.log("\n a,  8a\r\n `8, `8)                            ,adPPRg,\r\n  8)  ]8                        ,ad888888888b\r\n ,8' ,8'                    ,gPPR888888888888\r\n,8' ,8'                 ,ad8\"\"   `Y888888888P\r\n8)  8)              ,ad8\"\"        (8888888\"\"\r\n8,  8,          ,ad8\"\"            d888\"\"\r\n`8, `8,     ,ad8\"\"            ,ad8\"\"\r\n `8, `\" ,ad8\"\"            ,ad8\"\"\r\n    ,gPPR8b           ,ad8\"\"\r\n   dP:::::Yb      ,ad8\"\"\r\n   8):::::(8  ,ad8\"\"\r\n   Yb:;;;:d888\"\"  Yummy\r\n    \"8ggg8P\"      Nummy");
@@ -23,21 +23,36 @@ namespace LCShrinkRay.patches
 
             // Place things that should run after a player joins or leaves here vVVVVvvVVVVv
 
-            // re-enable renderers for all vent covers
             MeshRenderer renderer = GameObject.Find("VentEntrance").gameObject.transform.Find("Hinge").gameObject.transform.Find("VentCover").gameObject.GetComponentsInChildren<MeshRenderer>()[0];
-            renderer.enabled = true;
+            renderer.enabled = true; // re-enable renderers for all vent covers
 
-            GrabbablePlayerList.UpdateGrabbablePlayerObjects(); // todo: only add him instead
+            GrabbablePlayerList.BroadcastGrabbedPlayerObjectsList(clientId);
         }
 
         // Before client disconnects
         [HarmonyPatch(typeof(StartOfRound), "OnClientDisconnect")]
         [HarmonyPrefix]
-        public static void OnClientDisconnect(StartOfRound __instance, ulong clientId)
+        public static void OnClientDisconnect(ulong clientId)
         {
             Plugin.log("Player " + clientId + " left.");
 
-            GrabbablePlayerList.UpdateGrabbablePlayerObjects(); // todo: only remove him instead
+            if(PlayerHelper.currentPlayer().playerClientId == clientId)
+                return; // handled in Disconnect() below
+
+            var pcb = PlayerHelper.GetPlayerController(clientId);
+            if(pcb != null )
+                GrabbablePlayerList.RemovePlayerGrabbableIfExists(pcb);
         }
+
+        [HarmonyPatch(typeof(GameNetworkManager), "Disconnect")]
+        [HarmonyPrefix]
+        public static void OnDisconnect()
+        {
+            Plugin.log("We disconnected!");
+            GrabbablePlayerList.RemoveAllPlayerGrabbables();
+            return;
+        }
+
+
     }
 }

--- a/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
+++ b/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
@@ -12,30 +12,14 @@ namespace LCShrinkRay.patches
     [HarmonyPatch]
     internal class PlayerCountChangeDetection
     {
-        public static List<GameObject> currentPlayerList { get; set; }
-
-        [HarmonyPatch(typeof(StartOfRound), "SceneManager_OnLoadComplete1")]
-        [HarmonyPostfix()]
-        public static void Initialize()
-        {
-            currentPlayerList = PlayerHelper.getAllPlayers();
-        }
-
-        [HarmonyPatch(typeof(PlayerControllerB), "Update")]
+        // After client joined
+        [HarmonyPatch(typeof(StartOfRound), "OnClientConnect")]
         [HarmonyPostfix]
-        public static void OnUpdate(PlayerControllerB __instance)
+        public static void OnClientConnect(StartOfRound __instance, ulong clientId)
         {
-            var newPlayerList = PlayerHelper.getAllPlayers();
-            if (currentPlayerList == null || currentPlayerList.Count == newPlayerList.Count)
-            {
-                return;
-            }
-
-            currentPlayerList = newPlayerList;
-
             // cigarette
             Plugin.log("\n a,  8a\r\n `8, `8)                            ,adPPRg,\r\n  8)  ]8                        ,ad888888888b\r\n ,8' ,8'                    ,gPPR888888888888\r\n,8' ,8'                 ,ad8\"\"   `Y888888888P\r\n8)  8)              ,ad8\"\"        (8888888\"\"\r\n8,  8,          ,ad8\"\"            d888\"\"\r\n`8, `8,     ,ad8\"\"            ,ad8\"\"\r\n `8, `\" ,ad8\"\"            ,ad8\"\"\r\n    ,gPPR8b           ,ad8\"\"\r\n   dP:::::Yb      ,ad8\"\"\r\n   8):::::(8  ,ad8\"\"\r\n   Yb:;;;:d888\"\"  Yummy\r\n    \"8ggg8P\"      Nummy");
-            Plugin.log("Detected miscounted players, trying to update");
+            Plugin.log("Player " + clientId + " joined.");
 
             // Place things that should run after a player joins or leaves here vVVVVvvVVVVv
 
@@ -43,8 +27,17 @@ namespace LCShrinkRay.patches
             MeshRenderer renderer = GameObject.Find("VentEntrance").gameObject.transform.Find("Hinge").gameObject.transform.Find("VentCover").gameObject.GetComponentsInChildren<MeshRenderer>()[0];
             renderer.enabled = true;
 
-            // Self explains, plus I put a million comments around this function
-            GrabbablePlayerList.UpdateGrabbablePlayerObjects();
+            GrabbablePlayerList.UpdateGrabbablePlayerObjects(); // todo: only add him instead
+        }
+
+        // Before client disconnects
+        [HarmonyPatch(typeof(StartOfRound), "OnClientDisconnect")]
+        [HarmonyPrefix]
+        public static void OnClientDisconnect(StartOfRound __instance, ulong clientId)
+        {
+            Plugin.log("Player " + clientId + " left.");
+
+            GrabbablePlayerList.UpdateGrabbablePlayerObjects(); // todo: only remove him instead
         }
     }
 }

--- a/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
+++ b/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
@@ -17,6 +17,9 @@ namespace LCShrinkRay.patches
         [HarmonyPostfix]
         public static void OnClientConnect(ulong clientId)
         {
+            if (!PlayerHelper.isHost())
+                return;
+
             // cigarette
             Plugin.log("\n a,  8a\r\n `8, `8)                            ,adPPRg,\r\n  8)  ]8                        ,ad888888888b\r\n ,8' ,8'                    ,gPPR888888888888\r\n,8' ,8'                 ,ad8\"\"   `Y888888888P\r\n8)  8)              ,ad8\"\"        (8888888\"\"\r\n8,  8,          ,ad8\"\"            d888\"\"\r\n`8, `8,     ,ad8\"\"            ,ad8\"\"\r\n `8, `\" ,ad8\"\"            ,ad8\"\"\r\n    ,gPPR8b           ,ad8\"\"\r\n   dP:::::Yb      ,ad8\"\"\r\n   8):::::(8  ,ad8\"\"\r\n   Yb:;;;:d888\"\"  Yummy\r\n    \"8ggg8P\"      Nummy");
             Plugin.log("Player " + clientId + " joined.");
@@ -34,6 +37,9 @@ namespace LCShrinkRay.patches
         [HarmonyPrefix]
         public static void OnClientDisconnect(ulong clientId)
         {
+            if (!PlayerHelper.isHost())
+                return;
+
             Plugin.log("Player " + clientId + " left.");
 
             if(PlayerHelper.currentPlayer().playerClientId == clientId)

--- a/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
+++ b/LethalCompanyTemplate/patches/PlayerCountChangeDetection.cs
@@ -49,7 +49,7 @@ namespace LCShrinkRay.patches
         public static void OnDisconnect()
         {
             Plugin.log("We disconnected!");
-            GrabbablePlayerList.RemoveAllPlayerGrabbables();
+            GrabbablePlayerList.RemoveAllPlayerGrabbables(onlyLocal: true); // a clean up of all player grabbables that somehow survived
             return;
         }
 


### PR DESCRIPTION
NEW: Tooltips on ShrinkRay
FIX: Removal of GrabbablePlayerObjects when player leaves or enlarges (fixed memory leak)
NEW: Overhaul of ShrinkRay (getting most of shrinking.cs and being way more dynamic) & GrabbablePlayerList (added add/remove network calls for grabbable objects
NEW: Multiple Shrinking (to death if too small / growing again + removing grabbable object upon hitting normal size) -> growing beyond 1f is locked inNextEnlargingSize()
NEW: First draft for unsussification of vents (WIP)